### PR TITLE
slicesfix: fix incorrect slices lenghts

### DIFF
--- a/api.go
+++ b/api.go
@@ -38,9 +38,9 @@ func ChangeSpeed(sampleRate, numChannels int, speed, pitch, rate, volume float64
 	} else {
 		samples = samples[:len(out)]
 	}
+	copy(samples, out)
 
-	n := copy(samples, out)
-	return samples[:n], nil
+	return samples, nil
 }
 
 // ChangeFloatSpeed modifies the speed, pitch, rate, and volume of the provided float64 samples.

--- a/api.go
+++ b/api.go
@@ -36,11 +36,11 @@ func ChangeSpeed(sampleRate, numChannels int, speed, pitch, rate, volume float64
 	if cap(samples) < len(out) {
 		samples = make([]int16, len(out))
 	} else {
-		samples = samples[:len(out)-1]
+		samples = samples[:len(out)]
 	}
 
 	n := copy(samples, out)
-	return samples[:n-1], nil
+	return samples[:n], nil
 }
 
 // ChangeFloatSpeed modifies the speed, pitch, rate, and volume of the provided float64 samples.
@@ -65,7 +65,7 @@ func ChangeFloatSpeed(sampleRate, numChannels int, speed, pitch, rate, volume fl
 	if cap(samples) < len(out) {
 		samples = make([]float64, len(out))
 	} else {
-		samples = samples[:len(out)-1]
+		samples = samples[:len(out)]
 	}
 
 	for i := 0; i <= cap(samples) && i <= len(out); i++ {
@@ -98,7 +98,7 @@ func ChangeByteSpeed(sampleRate, numChannels int, speed, pitch, rate, volume flo
 	if cap(samples) < len(out) {
 		samples = make([]uint8, len(out))
 	} else {
-		samples = samples[:len(out)-1]
+		samples = samples[:len(out)]
 	}
 
 	for i := 0; i <= cap(samples) && i <= len(out); i++ {
@@ -156,7 +156,7 @@ func (stream *Stream) ReadTo(s []int16) ([]int16, error) {
 	if err != nil {
 		return s[:0], err
 	}
-	s = s[:len(data)-1]
+	s = s[:len(data)]
 	copy(s, data)
 
 	return s, nil

--- a/sonic_test.go
+++ b/sonic_test.go
@@ -242,7 +242,7 @@ func findPitchPeriodInRangeNativeA(b *SampleBuffer, minP, maxP int) (int, int, i
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
 
-	_ = samples[len(samples)-1]
+	_ = samples[len(samples)]
 
 	for period := minP; period <= maxP; period++ {
 		diff = 0
@@ -279,7 +279,7 @@ func findPitchPeriodInRangeNative(b *SampleBuffer, minP, maxP int) (int, int, in
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
 
-	_ = samples[len(samples)-1]
+	_ = samples[len(samples)]
 
 	for period := minP; period <= maxP; period++ {
 		diff = 0
@@ -319,7 +319,7 @@ func findPitchPeriodInRangeNativeAbs(b *SampleBuffer, minP, maxP int) (int, int,
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
 
-	_ = samples[len(samples)-1]
+	_ = samples[len(samples)]
 
 	for period := minP; period <= maxP; period++ {
 		diff = 0

--- a/sonic_test.go
+++ b/sonic_test.go
@@ -242,8 +242,6 @@ func findPitchPeriodInRangeNativeA(b *SampleBuffer, minP, maxP int) (int, int, i
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
 
-	_ = samples[len(samples)]
-
 	for period := minP; period <= maxP; period++ {
 		diff = 0
 
@@ -278,8 +276,6 @@ func findPitchPeriodInRangeNative(b *SampleBuffer, minP, maxP int) (int, int, in
 	minDiff = 1
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
-
-	_ = samples[len(samples)]
 
 	for period := minP; period <= maxP; period++ {
 		diff = 0
@@ -318,8 +314,6 @@ func findPitchPeriodInRangeNativeAbs(b *SampleBuffer, minP, maxP int) (int, int,
 	minDiff = 1
 	maxDiff = 0
 	samples, _ := b.GetSlice(2 * maxP)
-
-	_ = samples[len(samples)]
 
 	for period := minP; period <= maxP; period++ {
 		diff = 0


### PR DESCRIPTION
This PR addresses an issue with how output data slices are handled. Previously, the code used to = to[:len(data)-1], which incorrectly excluded the last byte from the output slice. The corrected approach is to use to = to[:len(data)] to ensure that the entire slice of copied data is included.

This fix ensures that all the bytes read into the slice are correctly reflected in the output.